### PR TITLE
GXLogicCore expected concrete class as TGraph

### DIFF
--- a/GraphX.Logic/Models/GXLogicCore.cs
+++ b/GraphX.Logic/Models/GXLogicCore.cs
@@ -111,17 +111,21 @@ namespace GraphX.Logic
         #endregion
         #endregion
 
-        public GXLogicCore()
+        public GXLogicCore(TGraph graph)
         {
             CreateNewAlgorithmFactory();
             CreateNewAlgorithmStorage(null, null, null);
-
-            Graph = (TGraph)Activator.CreateInstance(typeof(TGraph));
+            Graph = graph;
             EdgeSelfLoopCircleOffset = new Point(10, 10);
             EdgeCurvingTolerance = 8;
             EdgeSelfLoopCircleRadius = 10;
             EdgeShowSelfLooped = true;
             ParallelEdgeDistance = 5;
+        }
+
+        public GXLogicCore()
+            : this((TGraph)Activator.CreateInstance(typeof(TGraph)))
+        {
         }
 
         public void Dispose()


### PR DESCRIPTION
Added ctor taking TGraph to enable using pre-existing graph and allow for using an interface for TGraph (parameterless ctor tries to instansiate TGraph which will cause an runtime error if an interface is used).

Old parameterless ctor chained to the new one and still using CreateInstance so it's a non-breaking change.
