### PR TITLE
UpdateVertexEdges throws exception when trying to update VertextControl without Vertex

### DIFF
--- a/GraphX.Controls/Behaviours/DragBehaviour.cs
+++ b/GraphX.Controls/Behaviours/DragBehaviour.cs
@@ -253,7 +253,7 @@ namespace GraphX
 
         private static void UpdateVertexEdges(VertexControl vc)
         {
-            if (vc != null)
+            if (vc != null && vc.Vertex != null)
             {
                 var ra = vc.RootArea;
                 if (ra == null) throw new GX_InvalidDataException("OnDragFinished() - IGraphControl object must always have RootArea property set!");


### PR DESCRIPTION
If dragging a VertexControl while modifying the graph, UpdateVertexEdges would be called for a control without Vertex and RootArea and thus throwing and GX_InvalidDataException.
Edges should not be updated for a VertexControl lacking a Vertex.
