### PR TITLE
Proper calculation of label control position and angle.

### DIFF
--- a/Examples/ShowcaseApp.WPF/Templates/TestTemplates.xaml
+++ b/Examples/ShowcaseApp.WPF/Templates/TestTemplates.xaml
@@ -96,11 +96,11 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <Setter Property="RenderTransformOrigin" Value="0.5,0.5"></Setter>
         <Setter Property="RenderTransform">
             <Setter.Value>
-                <RotateTransform CenterX="0.5" CenterY="0.5" Angle="{Binding RelativeSource={RelativeSource AncestorType=gxl:EdgeLabelControl} , Path=Angle}"/>
+                <RotateTransform CenterX="0" CenterY="0" Angle="{Binding RelativeSource={RelativeSource AncestorType=gxl:EdgeLabelControl} , Path=Angle}"/>
             </Setter.Value>
         </Setter>
-
     </Style>
 </ResourceDictionary>

--- a/GraphX.Controls/Controls/EdgeLabels/EdgeLabelControl.cs
+++ b/GraphX.Controls/Controls/EdgeLabels/EdgeLabelControl.cs
@@ -105,7 +105,6 @@ namespace GraphX
             else Arrange(LastKnownRectSize);
         }
 
-        
 
         private static double GetLabelDistance(double edgeLength)
         {
@@ -190,32 +189,34 @@ namespace GraphX
                     p2 = newp2;
                 }
             }
-            // align the point so that it  passes through the center of the label content
-            var p = p1;
-            var desiredSize = DesiredSize;
-            p.Offset(-desiredSize.Width / 2, -desiredSize.Height / 2);
 
-            // move it "edgLength" on the segment
-            double tmpAngle;
-            var angleBetweenPoints = tmpAngle = MathHelper.GetAngleBetweenPoints(p1, p2);
-            //set angle in degrees
+            // The label control should be laid out on a rectangle, in the middle of the edge
+            var angleBetweenPoints = MathHelper.GetAngleBetweenPoints(p1, p2);
+            var desiredSize = DesiredSize;
+            bool flipAxis = p1.X > p2.X; // Flip axis if source is "after" target
+
+            // Calculate the center point of the edge
+            var centerPoint = new Point(p1.X + edgeLength * Math.Cos(angleBetweenPoints), p1.Y - edgeLength * Math.Sin(angleBetweenPoints));
             if (EdgeControl.AlignLabelsToEdges)
             {
-                if (p1.X > p2.X)
-                    tmpAngle = MathHelper.GetAngleBetweenPoints(p2, p1);
-                Angle = -tmpAngle * 180 / Math.PI;
+                // If we're aligning labels to the edges make sure add the label vertical offset
+                var yEdgeOffset = EdgeControl.LabelVerticalOffset;
+                if (flipAxis) // If we've flipped axis, move the offset to the other side of the edge
+                    yEdgeOffset = -yEdgeOffset;
+
+                // Adjust offset for rotation. Remember, the offset is perpendicular from the edge tangent.
+                // Slap on 90 degrees to the angle between the points, to get the direction of the offset.
+                centerPoint.Y -= yEdgeOffset * Math.Sin(angleBetweenPoints + Math.PI / 2);
+                centerPoint.X += yEdgeOffset * Math.Cos(angleBetweenPoints + Math.PI / 2);
+
+                // Angle is in degrees
+                Angle = -angleBetweenPoints * 180 / Math.PI;
+                if (flipAxis)
+                    Angle += 180; // Reorient the label so that it's always "pointing north"
             }
-  
-            p.Offset(edgeLength * Math.Cos(angleBetweenPoints), -edgeLength * Math.Sin(angleBetweenPoints));
-            if (EdgeControl.AlignLabelsToEdges)
-                p = MathHelper.RotatePoint(new Point(p.X, p.Y - EdgeControl.LabelVerticalOffset), p, Angle);
-            //optimized offset here
-            /*float x = 12.5f, y = 12.5f;
-            double sin = Math.Sin(angleBetweenPoints);
-            double cos = Math.Cos(angleBetweenPoints);
-            double sign = sin * cos / Math.Abs(sin * cos);
-            p.Offset(x * sin * sign + edgeLength * cos, y * cos * sign - edgeLength * sin);*/
-            LastKnownRectSize = new Rect(p.X,p.Y, desiredSize.Width, desiredSize.Height);
+
+            LastKnownRectSize = new Rect(centerPoint.X - desiredSize.Width / 2, centerPoint.Y - desiredSize.Height / 2, desiredSize.Width, desiredSize.Height);
+            
             Arrange(LastKnownRectSize);
         }
 


### PR DESCRIPTION
Hello Alexander,

here's a patch to EdgeLabelControl.UpdatePosition() and associated template (see TestTemplates.xaml under ShowcaseApp.WPF) to correctly position the label control with respect to edge orientation. Changes had to be made in the template: RotateTransform.CenterX & Y was set to 0.5 respectively. I believe these values were meant to be put in the RenderTransformOrigin property of the edge label control. 

The patch takes both alignment into account. I'm satisfied with the result. Does it fly with you?
