### PR TITLE
Store app async API

### DIFF
--- a/Examples/METRO.SimpleGraph/MainPage.xaml.cs
+++ b/Examples/METRO.SimpleGraph/MainPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -51,15 +52,32 @@ namespace METRO.SimpleGraph
             zc.ZoomToFill();
         }
 
-        void butGenerate_Click(object sender, RoutedEventArgs e)
+        private async void butGenerate_Click(object sender, RoutedEventArgs e)
         {
             GraphAreaExample_Setup();
-            graph.GenerateGraph(true);
+
+            try
+            {
+                await graph.GenerateGraphAsync(true);
+            }
+            catch (OperationCanceledException)
+            {
+                // User may have canceled
+            }
         }
 
-        void butRelayout_Click(object sender, RoutedEventArgs e)
+        async void butRelayout_Click(object sender, RoutedEventArgs e)
         {
-            graph.RelayoutGraph(); 
+            try
+            {
+                var t0 = DateTime.Now;
+                await graph.RelayoutGraphAsync();
+                Debug.WriteLine("Time elapsed: {0}", DateTime.Now - t0);
+            }
+            catch (OperationCanceledException)
+            {
+                // User may have canceled
+            }
         }
 
         void cboxEdgeRouting_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -80,12 +98,19 @@ namespace METRO.SimpleGraph
             graph.LogicCore.DefaultLayoutAlgorithm = (LayoutAlgorithmTypeEnum) cboxLayout.SelectedItem;
         }
 
-        void MainPage_Loaded(object sender, RoutedEventArgs e)
+        async void MainPage_Loaded(object sender, RoutedEventArgs e)
         {
             InitialSetup();
             GraphAreaExample_Setup();
 
-            graph.GenerateGraph(true);
+            try
+            {
+                await graph.GenerateGraphAsync(true);
+            }
+            catch (OperationCanceledException)
+            {
+                // User may have canceled
+            }
 
             //graph.RelayoutGraph(true);
             //zc.ZoomToFill();

--- a/Examples/METRO.SimpleGraph/Models/CurvedEr.cs
+++ b/Examples/METRO.SimpleGraph/Models/CurvedEr.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using GraphX;
 using GraphX.GraphSharp.Algorithms.EdgeRouting;
 using GraphX.Measure;
@@ -18,7 +19,7 @@ namespace InteractiveGraph.Models
             _curveOffset = prms != null ? prms.VerticalCurveOffset : 20;
         }
 
-        public override void Compute()
+        public override void Compute(CancellationToken cancellationToken)
         {
             EdgeRoutes.Clear();
             foreach (var edge in _graph.Edges)

--- a/GraphX.Controls/Controls/GraphArea.cs
+++ b/GraphX.Controls/Controls/GraphArea.cs
@@ -831,6 +831,7 @@ namespace GraphX
                 // Wait, but don't block the dispatcher, because the background task might be trying to execute on the UI thread.
                 Await(_layoutTask);
 
+                _layoutCancellationSource.Dispose();
                 _layoutCancellationSource = null;
                 _layoutTask = null;
             }

--- a/GraphX.METRO.Controls/Controls/GraphArea.cs
+++ b/GraphX.METRO.Controls/Controls/GraphArea.cs
@@ -698,7 +698,7 @@ namespace GraphX
 
         private async Task _relayoutGraphMainAsync(CancellationToken externalCancellationToken, bool generateAllEdges = false, bool standalone = true)
         {
-            await CancelRelayout();
+            await CancelRelayoutAsync();
 
             _layoutCancellationSource = new CancellationTokenSource();
 
@@ -713,7 +713,7 @@ namespace GraphX
         private CancellationTokenSource _layoutCancellationSource;
         private CancellationTokenSource _linkedLayoutCancellationSource;
 
-        public async Task CancelRelayout()
+        public async Task CancelRelayoutAsync()
         {
             if (_layoutTask != null)
             {

--- a/GraphX.METRO.Controls/Models/DispatcherHelper.cs
+++ b/GraphX.METRO.Controls/Models/DispatcherHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.UI.Core;
 using Windows.UI.Xaml;
@@ -7,20 +8,14 @@ namespace GraphX
 {
     public static class DispatcherHelper
     {
-        public static CoreDispatcher UiDispatcher { get; private set; }
-
         public static async Task CheckBeginInvokeOnUi(Action action)
         {
-            if (UiDispatcher.HasThreadAccess)
-                action();
-            else await UiDispatcher.RunAsync(CoreDispatcherPriority.Normal,
-                                       () => action());
-        }
+            var dispatcher = Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher;
 
-        static DispatcherHelper()
-        {
-            if (UiDispatcher != null) return;
-            UiDispatcher = Window.Current.Dispatcher;
+            if (dispatcher.HasThreadAccess)
+                action();
+            else await dispatcher.RunAsync(CoreDispatcherPriority.Normal,
+                                       () => action());
         }
     }
 }


### PR DESCRIPTION
This patch completes pull request #9, such that it makes the store app control follow the async/await pattern. Breaking API changes:
- `RelayoutGraph` -> `RelayoutGraphAsync`
- `GenerateGraph` -> `GenerateGraphAsync`
- New method: `CancelRelayoutAsync` (brings control in par with WPF control)

All methods (except `CancelRelayoutAsync`) may be passed an optional `CancellationToken` that may be used to cancel the operation. This token is linked to an internal cancellation token source, making it possible to cancel an operation by means of the passed in token, or a call to `CancelRelayoutAsync`.

I also fixed two bugs: `DispatcherHelper` grabbed a reference to the UI thread dispatcher in a way that is not safe. It attempted to get a reference when the source was not yet populated. The safe way to get hold of the reference is through the rather long name `Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher`.

The second bug was one I introduced in #9: The cancellation token source was not disposed.
