### PR TITLE
Use ControlFactory for edge deserialization

### DIFF
--- a/GraphX.Controls/Controls/GraphArea.cs
+++ b/GraphX.Controls/Controls/GraphArea.cs
@@ -1515,7 +1515,7 @@ namespace GraphX.WPF.Controls
 
                 if (datasource == null || datatarget == null)
                     throw new GX_SerializationException("DeserializeFromFile() -> Serialization logic is broken! Vertex not found. All vertices must be processed before edges!");
-                var ecc = new EdgeControl { Edge = edgedata, Source = _vertexlist[datasource], Target = _vertexlist[datatarget], DataContext = edgedata};
+                var ecc = ControlFactory.CreateEdgeControl(_vertexlist[datasource], _vertexlist[datatarget], edgedata);
                 InsertEdge(edgedata, ecc);
                 LogicCore.Graph.AddEdge(edgedata);
             }


### PR DESCRIPTION
The deserialization code was using ControlFactory for vertexes, but not for edges. I have a need to use custom edge controls and modified the code to use ControlFactory for edges upon deserialization.
