### PR TITLE
EdgeControl.ShowArrows as a DependencyProperty

### DIFF
--- a/Examples/ShowcaseApp.WPF/Pages/EdgeRoutingGraph.xaml.cs
+++ b/Examples/ShowcaseApp.WPF/Pages/EdgeRoutingGraph.xaml.cs
@@ -98,7 +98,7 @@ namespace ShowcaseApp.WPF.Pages
         void erg_randomizeArrows_Click(object sender, RoutedEventArgs e)
         {
             foreach (var item in erg_Area.EdgesList.ToList())
-                item.Value.ShowArrows = Convert.ToBoolean(ShowcaseHelper.Rand.Next(0, 2));
+                item.Value.SetCurrentValue(EdgeControl.ShowArrowsProperty, Convert.ToBoolean(ShowcaseHelper.Rand.Next(0, 2)));
         }
 
         void erg_showEdgeLabels_Checked(object sender, RoutedEventArgs e)

--- a/GraphX.Controls/Controls/EdgeControl.cs
+++ b/GraphX.Controls/Controls/EdgeControl.cs
@@ -182,23 +182,25 @@ namespace GraphX.WPF.Controls
         /// </summary>
         public bool IsHiddenEdgesUpdated { get; set; }
 
+        public static readonly DependencyProperty ShowArrowsProperty = DependencyProperty.Register("ShowArrows", typeof(bool), typeof(EdgeControl), new PropertyMetadata(true, showarrows_changed));
+
+        private static void showarrows_changed(object sender, DependencyPropertyChangedEventArgs args)
+        {
+            var ctrl = sender as EdgeControl;
+            if (ctrl == null)
+                return;
+
+            if (ctrl._edgePointerForSource != null && !ctrl.IsSelfLooped)
+                if (ctrl.ShowArrows) ctrl._edgePointerForSource.Show(); else ctrl._edgePointerForSource.Hide();
+            if (ctrl._edgePointerForTarget != null && !ctrl.IsSelfLooped)
+                if (ctrl.ShowArrows) ctrl._edgePointerForTarget.Show(); else ctrl._edgePointerForTarget.Hide();
+            ctrl.UpdateEdge(false);
+        }
 
         /// <summary>
         /// Show arrows on the edge ends. Default value is true.
         /// </summary>
-        public bool ShowArrows { 
-            get { return _showarrows; } 
-            set { 
-                _showarrows = value;
-                if (_edgePointerForSource != null && !IsSelfLooped)
-                    if(value) _edgePointerForSource.Show(); else _edgePointerForSource.Hide();
-                if (_edgePointerForTarget != null && !IsSelfLooped)
-                    if (value) _edgePointerForTarget.Show(); else _edgePointerForTarget.Hide();
-                UpdateEdge(false); 
-            } 
-        }
-        private bool _showarrows;
-
+        public bool ShowArrows { get { return (bool)GetValue(ShowArrowsProperty); } set { SetValue(ShowArrowsProperty, value); } }
 
         public static readonly DependencyProperty ShowLabelProperty = DependencyProperty.Register("ShowLabel",
                                                                                typeof(bool),
@@ -365,7 +367,7 @@ namespace GraphX.WPF.Controls
             DataContext = edge;
             Source = source; Target = target;
             Edge = edge; DataContext = edge;
-            ShowArrows = showArrows;
+            SetCurrentValue(ShowArrowsProperty, showArrows);
             ShowLabel = showLabels;
             _updateLabelPosition = true;
             IsHiddenEdgesUpdated = true;

--- a/GraphX.Controls/Controls/GraphArea.cs
+++ b/GraphX.Controls/Controls/GraphArea.cs
@@ -955,7 +955,7 @@ namespace GraphX.WPF.Controls
         private void ReapplySingleEdgeVisualProperties(EdgeControl item)
         {
             if (_svEdgeDashStyle != null) item.DashStyle = _svEdgeDashStyle.Value;
-            if (_svShowEdgeArrows != null) item.ShowArrows = _svShowEdgeArrows.Value;
+            if (_svShowEdgeArrows != null) item.SetCurrentValue(EdgeControl.ShowArrowsProperty, _svShowEdgeArrows.Value);
             if (_svShowEdgeLabels != null) item.ShowLabel = _svShowEdgeLabels.Value;
             if (_svAlignEdgeLabels != null) item.AlignLabelsToEdges = _svAlignEdgeLabels.Value;
             if (_svUpdateLabelPosition != null) item.UpdateLabelPosition = _svUpdateLabelPosition.Value;
@@ -993,7 +993,7 @@ namespace GraphX.WPF.Controls
         {
             _svShowEdgeArrows = isEnabled;
             foreach (var item in _edgeslist.Values)
-                item.ShowArrows = isEnabled;
+                item.SetCurrentValue(EdgeControl.ShowArrowsProperty, isEnabled);
         }
 
         private bool? _svShowEdgeLabels;


### PR DESCRIPTION
Here is another small change that I made for a project I am working on. These modifications convert EdgeControl.ShowArrows into a DependencyProperty so it is compatible with bindings. One thing I'm doing that's different from the similar properties in the existing code is the use of SetCurrentValue. This allows actions like those of ReapplySingleEdgeVisualProperties to work without breaking existing bindings.

As with my previous pull-request, I have only changed the WPF version of the control. Someday, I will update my OS and will be able to change the METRO code at the same time. For now, I apologize, but I must leave that to you if you want to incorporate these changes.

Thanks.

Jon
