### PR TITLE
AutoresolveIds consistency

### DIFF
--- a/Examples/ShowcaseApp.WPF/Models/ShowcaseHelper.cs
+++ b/Examples/ShowcaseApp.WPF/Models/ShowcaseHelper.cs
@@ -45,7 +45,7 @@ namespace ShowcaseApp.WPF.Models
                 graph.AddVertex(new DataVertex(item.Text) { ID = item.ID, ImageId = Rand.Next(0,3)});
 
             var vlist = graph.Vertices.ToList();
-            var cnt = 1;
+            var edgeId = count + 1;
 
             if (!addEdges) return graph;
 
@@ -54,8 +54,8 @@ namespace ShowcaseApp.WPF.Models
                 if (Rand.Next(0, 50) > 25) continue;
                 var vertex2 = vlist[Rand.Next(0, graph.VertexCount - 1)];
                 var txt = string.Format("{0} -> {1}", item.Text, vertex2.Text);
-                graph.AddEdge(new DataEdge(item, vertex2, Rand.Next(1, 50)) { ID = cnt, Text = txt, ToolTipText = txt });
-                cnt++;
+                graph.AddEdge(new DataEdge(item, vertex2, Rand.Next(1, 50)) { ID = edgeId, Text = txt, ToolTipText = txt });
+                edgeId++;
             }
             return graph;
         }


### PR DESCRIPTION
I've been having some problems with duplicate IDs when using the GraphArea.AutoAssignMissingDataId feature. There are cases where newly added vertices or edges get duplicate IDs and then have problems after serializing and deserializing. One manifestation of the problem is that after deserialization, edges connect to the wrong vertices.

I am open to the idea that I'm missing some step in my own code. However, I found some possible issues in the way AutoResolveIds is doing its work. If GetNextUniqueId() is intended to be used for vertices AND edges, I think it's necessary to ensure all IDs are unique and _dataIdsCollection contains all IDs.

The GraphArea AutoresolveIds method was clearing _dataIdsCollection and
resetting _dataIdCounter between vertex and edge processing. This often
resulted in GetNextUniqueId returning IDs that were already in use.

Additionally, if the graph was populated by deserialization,
_dataIdsCollection was not populated with the IDs pulled in during
deserialization. So, the next generated ID could be a duplicate. Calling
AutoresolveIds() takes care of that.

After making changes to GraphArea, I saw that ShowcaseHelper is generating edge IDs starting at 1. I modified it to start with the next ID after the last vertex.

If I'm wrong about the need for all IDs to be unique and/or this was already working as intended, I might need to ask some questions about what steps I am missing in my own code.

Thanks again.

Jon
