### PR TITLE
Update IGraphXEdge.cs to support new ReversePath property

### DIFF
--- a/GraphX.PCL.Common/Interfaces/IGraphXEdge.cs
+++ b/GraphX.PCL.Common/Interfaces/IGraphXEdge.cs
@@ -34,5 +34,9 @@
         /// Optional parameter to bind edge to static vertex connection point
         /// </summary>
         int? TargetConnectionPointId { get; }
-    }
+    
+		/// <summary>
+		/// Reverse the calculated routing path points.
+		/// </summary>
+		bool ReversePath { get; set; }}
 }


### PR DESCRIPTION
Added support for reversing the geometry.  This is required for animating shapes along a path where the direction needs to be reversed without using the Storyboard.AutoReverse property.
