### PR TITLE
Update EdgeBase.cs to support new ReversePath property.

### DIFF
--- a/GraphX.PCL.Common/Models/EdgeBase.cs
+++ b/GraphX.PCL.Common/Models/EdgeBase.cs
@@ -67,5 +67,9 @@ namespace GraphX.PCL.Common.Models
         /// </summary>
         public double Weight { get; set; }
 
+		/// <summary>
+		/// Reverse the calculated routing path points.
+		/// </summary>
+		public bool ReversePath { get; set; }
     }
 }


### PR DESCRIPTION
Added support for reversing the geometry.  This is required for animating shapes along a path where the direction needs to be reversed without using the Storyboard.AutoReverse property.
