### PR TITLE
Zoom not always wanted when applying template

### DIFF
--- a/GraphX.Controls/Controls/ZoomControl/ZoomControl.cs
+++ b/GraphX.Controls/Controls/ZoomControl/ZoomControl.cs
@@ -1586,7 +1586,10 @@ namespace GraphX.Controls
                     }
                 };
             }
-            ZoomToFill();
+            if (Mode == ZoomControlModes.Fill)
+            {
+                DoZoomToFill();
+            }
         }
 
         public event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
When applying a template, ZoomControl did not consider the Mode setting.
