### PR TITLE
Modifications to allow visibility control from styles

### DIFF
--- a/GraphX.Controls/Controls/EdgeControlBase.cs
+++ b/GraphX.Controls/Controls/EdgeControlBase.cs
@@ -578,7 +578,7 @@ namespace GraphX.Controls
                 //pregenerate built-in indicator geometry if template PART is absent
                 if (!HasSelfLoopedEdgeTemplate)
                     _linegeometry = new EllipseGeometry();
-                else SelfLoopIndicator.Visibility = Visibility.Visible;
+                else SelfLoopIndicator.SetCurrentValue(UIElement.VisibilityProperty, Visibility.Visible);
             }
             else
             {
@@ -586,7 +586,7 @@ namespace GraphX.Controls
                 //if (_edgePointerForTarget != null && ShowArrows) _edgePointerForTarget.Show();
 
                 if (HasSelfLoopedEdgeTemplate)
-                    SelfLoopIndicator.Visibility = Visibility.Collapsed;
+                    SelfLoopIndicator.SetCurrentValue(UIElement.VisibilityProperty, Visibility.Collapsed);
             }
         }
 

--- a/GraphX.Controls/Controls/EdgeLabels/EdgeLabelControl.cs
+++ b/GraphX.Controls/Controls/EdgeLabels/EdgeLabelControl.cs
@@ -125,12 +125,12 @@ namespace GraphX.Controls
         public void Show()
         {
             if (EdgeControl.IsSelfLooped && !DisplayForSelfLoopedEdges) return;
-            Visibility = Visibility.Visible;
+            SetCurrentValue(UIElement.VisibilityProperty, Visibility.Visible);
         }
 
         public void Hide()
         {
-            Visibility = Visibility.Collapsed;
+            SetCurrentValue(UIElement.VisibilityProperty, Visibility.Collapsed);
         }
 
 

--- a/GraphX.Controls/Controls/EdgePointers/DefaultEdgePointer.cs
+++ b/GraphX.Controls/Controls/EdgePointers/DefaultEdgePointer.cs
@@ -53,12 +53,12 @@ namespace GraphX.Controls
 
         public void Show()
         {
-            Visibility = Visibility.Visible;
+            SetCurrentValue(UIElement.VisibilityProperty, Visibility.Visible);
         }
 
         public void Hide()
         {
-            Visibility = Visibility.Collapsed;
+            SetCurrentValue(UIElement.VisibilityProperty, Visibility.Collapsed);
         }
 
         private static EdgeControl GetEdgeControl(DependencyObject parent)

--- a/GraphX.Controls/Controls/GraphArea.cs
+++ b/GraphX.Controls/Controls/GraphArea.cs
@@ -513,8 +513,7 @@ namespace GraphX.Controls
                 {
                     if (VertexList.ContainsKey(item.Key))
                         VertexList[item.Key].SetPosition(item.Value);
-                    if(showObjectsIfPosSpecified)
-                        VertexList[item.Key].Visibility = Visibility.Visible;
+                    VertexList[item.Key].SetCurrentValue(GraphAreaBase.PositioningCompleteProperty, true);
                 }
             }
             UpdateLayout();
@@ -545,7 +544,7 @@ namespace GraphX.Controls
             {
                 var vc = ControlFactory.CreateVertexControl(it);
                 vc.DataContext = dataContextToDataItem ? it : null;
-                vc.Visibility = Visibility.Hidden; // make them invisible (there is no layout positions yet calculated)
+                vc.SetCurrentValue(GraphAreaBase.PositioningCompleteProperty, false); // Style can make them invisible until positioning is complete (after layout positions are calculated)
                 InternalAddVertex(it, vc);
             }
             if (forceVisPropRecovery)
@@ -611,7 +610,7 @@ namespace GraphX.Controls
                     if (MoveAnimation == null || double.IsNaN(GetX(vc)))
                         vc.SetPosition(item.Value.X,item.Value.Y, false);
                     else MoveAnimation.AddVertexData(vc, item.Value);
-                    vc.Visibility = Visibility.Visible; //show vertexes with layout positions assigned
+                    vc.SetCurrentValue(GraphAreaBase.PositioningCompleteProperty, true); // Style can show vertexes with layout positions assigned
                 }
                 if (MoveAnimation != null) 
                 {

--- a/GraphX.Controls/Controls/GraphAreaBase.cs
+++ b/GraphX.Controls/Controls/GraphAreaBase.cs
@@ -86,6 +86,9 @@ namespace GraphX
             d.SetValue(TopProperty, e.NewValue);
         }
 
+        public static readonly DependencyProperty PositioningCompleteProperty =
+            DependencyProperty.RegisterAttached("PositioningComplete", typeof(bool), typeof(GraphAreaBase), new FrameworkPropertyMetadata(true));
+
         #endregion
 
         #region Child EVENTS
@@ -606,6 +609,17 @@ namespace GraphX
         public static void SetFinalY(DependencyObject obj, double value)
         {
             obj.SetValue(FinalYProperty, value);
+        }
+
+        [AttachedPropertyBrowsableForChildren]
+        public static bool GetPositioningComplete(DependencyObject obj)
+        {
+            return (bool)obj.GetValue(PositioningCompleteProperty);
+        }
+
+        public static void SetPositioningComplete(DependencyObject obj, bool value)
+        {
+            obj.SetValue(PositioningCompleteProperty, value);
         }
         #endregion
 

--- a/GraphX.Controls/Controls/VertexConnectionPoints/StaticVertexConnectionPoint.cs
+++ b/GraphX.Controls/Controls/VertexConnectionPoints/StaticVertexConnectionPoint.cs
@@ -52,12 +52,12 @@ namespace GraphX.Controls
 
         public void Show()
         {
-            Visibility = Visibility.Visible;
+            SetCurrentValue(UIElement.VisibilityProperty, Visibility.Visible);
         }
 
         public void Hide()
         {
-            Visibility = Visibility.Collapsed;
+            SetCurrentValue(UIElement.VisibilityProperty, Visibility.Collapsed);
         }
 
         private static VertexControl GetVertexControl(DependencyObject parent)

--- a/GraphX.Controls/Controls/VertexLabels/VertexLabelControl.cs
+++ b/GraphX.Controls/Controls/VertexLabels/VertexLabelControl.cs
@@ -172,12 +172,12 @@ namespace GraphX.Controls
 
         public void Hide()
         {
-            Visibility = Visibility.Collapsed;
+            SetCurrentValue(UIElement.VisibilityProperty, Visibility.Collapsed);
         }
 
         public void Show()
         {
-            Visibility = Visibility.Visible;
+            SetCurrentValue(UIElement.VisibilityProperty, Visibility.Visible);
         }
 
         void VertexLabelControl_LayoutUpdated(object sender, DefaultEventArgs e)

--- a/GraphX.Controls/Controls/ZoomControl/ZoomControl.cs
+++ b/GraphX.Controls/Controls/ZoomControl/ZoomControl.cs
@@ -1561,7 +1561,7 @@ namespace GraphX.Controls
             if (DesignerProperties.GetIsInDesignMode(this))
             {
                 if (ViewFinder != null)
-                    ViewFinder.Visibility = Visibility.Collapsed;
+                    ViewFinder.SetCurrentValue(UIElement.VisibilityProperty, Visibility.Collapsed);
                 return;
             }
 

--- a/GraphX.Controls/Models/GraphControlFactory.cs
+++ b/GraphX.Controls/Models/GraphControlFactory.cs
@@ -18,8 +18,8 @@ namespace GraphX.Controls.Models
 
         public EdgeControl CreateEdgeControl(VertexControl source, VertexControl target, object edge, bool showLabels = false, bool showArrows = true, Visibility visibility = Visibility.Visible)
         {
-            var edgectrl = new EdgeControl(source, target, edge, showLabels, showArrows) { Visibility = visibility, RootArea = FactoryRootArea};
-
+            var edgectrl = new EdgeControl(source, target, edge, showLabels, showArrows) { RootArea = FactoryRootArea};
+            edgectrl.SetCurrentValue(UIElement.VisibilityProperty, visibility);
             return edgectrl;
 
         }

--- a/GraphX.Controls/Models/StateStorage.cs
+++ b/GraphX.Controls/Models/StateStorage.cs
@@ -96,7 +96,7 @@ namespace GraphX.Controls.Models
             foreach (var item in _states[id].VertexPositions)
             {
                 _area.VertexList[item.Key].SetPosition(item.Value.X, item.Value.Y);
-                _area.VertexList[item.Key].Visibility = Visibility.Visible;
+                _area.VertexList[item.Key].SetCurrentValue(GraphAreaBase.PositioningCompleteProperty, true);
             }
             //setup visible edges
             foreach (var item in _states[id].VisibleEdges)

--- a/GraphX.Controls/Themes/Generic.xaml
+++ b/GraphX.Controls/Themes/Generic.xaml
@@ -1,8 +1,9 @@
 ﻿<ResourceDictionary
-	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options"
-    xmlns:graphx="clr-namespace:GraphX.Controls">    
+    xmlns:graphx="clr-namespace:GraphX.Controls"
+    xmlns:graphxRoot="clr-namespace:GraphX">
 
     <graphx:DoubleToLog10Converter x:Key="Log10Converter" />
     <graphx:EqualityToBooleanConverter x:Key="EqualityConverter" />
@@ -455,23 +456,28 @@
         <Setter Property="BorderThickness" Value="5,3,5,3"/>
         <Setter Property="Padding" Value="10,5,10,5"/>
         <Setter Property="BorderBrush" Value="#FF393939"/>
-        
+
         <Setter Property="Template">
-			<Setter.Value>
+            <Setter.Value>
                 <ControlTemplate TargetType="{x:Type graphx:VertexControl}">
-					<Border Background="{TemplateBinding Background}" 
+                    <Border Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
-							CornerRadius="10,10,10,10"
-						Padding="{TemplateBinding Padding}">
+                            CornerRadius="10,10,10,10"
+                        Padding="{TemplateBinding Padding}">
                         <Grid>
                             <ContentPresenter Content="{TemplateBinding Vertex}" />
                             <graphx:VertexLabelControl x:Name="PART_vertexLabel" Content="{Binding Vertex, RelativeSource={RelativeSource TemplatedParent}}" />
                         </Grid>
                     </Border>
                 </ControlTemplate>
-			</Setter.Value>
-		</Setter>	
-	</Style>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="graphxRoot:GraphAreaBase.PositioningComplete" Value="False">
+                <Setter Property="Visibility" Value="Hidden"/>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
     <!-- ENDREGION -->
 
     <!-- REGION EDGE CONTROL -->


### PR DESCRIPTION
There were several places in the code where the Visibility property was
being set as a local value. That interferes with the use of styles to
control visibility. I modified each place where Visibility was set as a
local value to use SetCurrentValue instead.

In the case of VertexControl, a bit more was needed. The sequence of
events to hide and show VertexControl during the layout process was
still calling SetCurrentValue after my style triggers. So, I created the
GraphAreaBase.PositioningComplete attached property and manipulate that
instead. When the layout is in progress and the controls should be
hidden, the attached property is set false and a VertexControl style
trigger can set the property to Hidden. When the layout is complete and
the controls are positioned, the property is set to true and the style
trigger is no longer in effect. Then my style triggers can take over and
properly control the visibility.
