### PR TITLE
Click event for VertexControl

### DIFF
--- a/GraphX.Controls/Behaviours/DragBehaviour.cs
+++ b/GraphX.Controls/Behaviours/DragBehaviour.cs
@@ -103,31 +103,74 @@ namespace GraphX.Controls
             {
                 //register the event handlers
 #if WPF
-                element.MouseMove += OnDragging;
+                element.MouseLeftButtonDown += OnDragStarted;
+                element.PreviewMouseLeftButtonUp += OnDragFinished;
 #elif METRO
-                element.PointerMoved += OnDragging;
+                element.PointerPressed += OnDragStarted;
+				element.PointerReleased += OnDragFinished;
 #endif
             }
             else
             {
                 //unregister the event handlers
 #if WPF
-                element.MouseMove -= OnDragging;
+                element.MouseLeftButtonDown -= OnDragStarted;
                 element.PreviewMouseLeftButtonUp -= OnDragFinished;
 #elif METRO
-                element.PointerMoved -= OnDragging;
-                element.PointerReleased -= OnDragFinished;
+                element.PointerPressed -= OnDragStarted;
+				element.PointerReleased -= OnDragFinished;
 #endif
             }
         }
         #endregion
 
         private static Point _scale = new Point(1, 1);
+#if WPF
+        private static void OnDragStarted(object sender, System.Windows.Input.MouseButtonEventArgs e)
+#elif METRO
+		private static void OnDragStarted( object sender, PointerRoutedEventArgs e )
+#endif
+        {
+            var obj = sender as DependencyObject;
+            //we are starting the drag
+            SetIsDragging(obj, true);
+
+#if WPF
+            var pos = e.GetPosition(obj as IInputElement);
+#elif METRO
+			var pos = e.GetCurrentPoint(obj as UIElement).Position;
+#endif
+
+            //save the position of the mouse to the start position
+            SetOriginalX(obj, pos.X);
+            SetOriginalY(obj, pos.Y);
+
+            //capture the mouse
+#if WPF
+            var element = obj as IInputElement;
+            if (element != null)
+            {
+                element.CaptureMouse();
+                element.MouseMove -= OnDragging;
+                element.MouseMove += OnDragging;
+            }
+            //else throw new GX_InvalidDataException("The control must be a descendent of the FrameworkElement or FrameworkContentElement!");
+            e.Handled = false;
+#elif METRO
+            var element = obj as FrameworkElement;
+			if ( element != null )
+			{
+				element.CapturePointer(e.Pointer);
+				element.PointerMoved += OnDragging;
+			}
+            e.Handled = true;
+#endif
+        }
 
 #if WPF
         private static void OnDragFinished(object sender, System.Windows.Input.MouseButtonEventArgs e)
 #elif METRO
-        private static void OnDragFinished( object sender, PointerRoutedEventArgs e )
+		private static void OnDragFinished( object sender, PointerRoutedEventArgs e )
 #endif
         {
             UpdateVertexEdges(sender as VertexControl);
@@ -142,69 +185,35 @@ namespace GraphX.Controls
             var element = sender as IInputElement;
             if (element != null)
             {
+                element.MouseMove -= OnDragging;
                 element.ReleaseMouseCapture();
-                element.PreviewMouseLeftButtonUp -= OnDragFinished;
             }
 #elif METRO
             var element = sender as FrameworkElement;
-            if ( element != null )
-            {
-                element.ReleasePointerCapture(e.Pointer);
-                element.PointerReleased -= OnDragFinished;
-            }
-            e.Handled = true;
+			if ( element != null )
+			{
+				element.PointerMoved -= OnDragging;
+				element.ReleasePointerCapture(e.Pointer);
+			}
 #endif
+            //e.Handled = true;
         }
 
 #if WPF
         private static void OnDragging(object sender, System.Windows.Input.MouseEventArgs e)
 #elif METRO
-        private static void OnDragging( object sender, PointerRoutedEventArgs e )
+		private static void OnDragging( object sender, PointerRoutedEventArgs e )
 #endif
         {
-            if (e.LeftButton != System.Windows.Input.MouseButtonState.Pressed)
-            {
-                return;
-            }
-
             var obj = sender as DependencyObject;
-#if WPF
-            var pos = e.GetPosition(obj as IInputElement);
-#elif METRO
-            var pos = e.GetCurrentPoint(obj as UIElement).Position;
-#endif
-
             if (!GetIsDragging(obj))
-            {
-                //we are starting the drag
-                SetIsDragging(obj, true);
-
-                //save the position of the mouse to the start position
-                SetOriginalX(obj, pos.X);
-                SetOriginalY(obj, pos.Y);
-
-                //capture the mouse
-#if WPF
-                var element = obj as IInputElement;
-                if (element != null)
-                {
-                    element.CaptureMouse();
-                    element.PreviewMouseLeftButtonUp += OnDragFinished;
-                }
-                //else throw new GX_InvalidDataException("The control must be a descendent of the FrameworkElement or FrameworkContentElement!");
-                e.Handled = true;
-#elif METRO
-                var element = obj as FrameworkElement;
-                if ( element != null )
-                {
-                    element.CapturePointer(e.Pointer);
-                    element.PointerReleased += OnDragFinished;
-                }
-                e.Handled = true;
-#endif
                 return;
-            }
 
+#if WPF
+            Point pos = e.GetPosition(obj as IInputElement);
+#elif METRO
+            Point pos = e.GetCurrentPoint(obj as UIElement).Position;
+#endif
             double horizontalChange = (pos.X - GetOriginalX(obj)) * _scale.X;
             double verticalChange = (pos.Y - GetOriginalY(obj)) * _scale.Y;
             if (GetIsTagged(obj))

--- a/GraphX.Controls/Controls/VertexControl.cs
+++ b/GraphX.Controls/Controls/VertexControl.cs
@@ -107,7 +107,8 @@ namespace GraphX.Controls
 
         #region Events handling
 
-        private bool clickTrack = false;
+		private bool clickTrack = false;
+		private Point clickTrackPoint;
 
         internal void UpdateEventhandling(EventType typ)
         {
@@ -150,7 +151,17 @@ namespace GraphX.Controls
 
         void VertexControl_PreviewMouseMove(object sender, MouseEventArgs e)
         {
-            clickTrack = false;
+			if (!clickTrack)
+				return;
+
+			Point curPoint;
+			if (RootArea != null)
+				curPoint = Mouse.GetPosition(RootArea);
+			else
+				curPoint = new Point();
+
+			if (curPoint != clickTrackPoint)
+				clickTrack = false;
         }
 
         void VertexControl_MouseUp(object sender, MouseButtonEventArgs e)
@@ -196,9 +207,10 @@ namespace GraphX.Controls
 
         void VertexControl_Down(object sender, MouseButtonEventArgs e)
         {
-            if (RootArea != null && Visibility == Visibility.Visible)
-                RootArea.OnVertexSelected(this, e, Keyboard.Modifiers);
+			if (RootArea != null && Visibility == Visibility.Visible)
+				RootArea.OnVertexSelected(this, e, Keyboard.Modifiers);
             clickTrack = true;
+			clickTrackPoint = RootArea != null ? Mouse.GetPosition(RootArea) : new Point();
             e.Handled = true;
         }
         #endregion

--- a/GraphX.Controls/Controls/VertexControl.cs
+++ b/GraphX.Controls/Controls/VertexControl.cs
@@ -107,13 +107,23 @@ namespace GraphX.Controls
 
         #region Events handling
 
+        private bool clickTrack = false;
+
         internal void UpdateEventhandling(EventType typ)
         {
             switch (typ)
             {
                 case EventType.MouseClick:
-                    if (EventOptions.MouseClickEnabled) MouseDown += VertexControl_Down;
-                    else MouseDown -= VertexControl_Down;
+                    if (EventOptions.MouseClickEnabled)
+                    {
+                        MouseDown += VertexControl_Down;
+                        PreviewMouseMove += VertexControl_PreviewMouseMove;
+                    }
+                    else
+                    {
+                        MouseDown -= VertexControl_Down;
+                        PreviewMouseMove -= VertexControl_PreviewMouseMove;
+                    }
                     break;
                 case EventType.MouseDoubleClick:
                     if (EventOptions.MouseDoubleClickEnabled) MouseDoubleClick += VertexControl_MouseDoubleClick;
@@ -138,10 +148,22 @@ namespace GraphX.Controls
             MouseUp += VertexControl_MouseUp;
         }
 
+        void VertexControl_PreviewMouseMove(object sender, MouseEventArgs e)
+        {
+            clickTrack = false;
+        }
+
         void VertexControl_MouseUp(object sender, MouseButtonEventArgs e)
         {
             if (RootArea != null && Visibility == Visibility.Visible)
+            {
                 RootArea.OnVertexMouseUp(this, e, Keyboard.Modifiers);
+                if (clickTrack)
+                {
+                    RaiseClick();
+                }
+            }
+            clickTrack = false;
             e.Handled = true;
         }
 
@@ -169,15 +191,33 @@ namespace GraphX.Controls
         {
             if (RootArea != null && Visibility == Visibility.Visible)
                 RootArea.OnVertexDoubleClick(this);
-            e.Handled = true;
+            //e.Handled = true;
         }
 
         void VertexControl_Down(object sender, MouseButtonEventArgs e)
         {
             if (RootArea != null && Visibility == Visibility.Visible)
                 RootArea.OnVertexSelected(this, e, Keyboard.Modifiers);
+            clickTrack = true;
             e.Handled = true;
         }
+        #endregion
+
+        #region Click Event
+
+        public static readonly RoutedEvent ClickEvent = EventManager.RegisterRoutedEvent("Click", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(VertexControl));
+        public event RoutedEventHandler Click
+        {
+            add { AddHandler(ClickEvent, value); }
+            remove { RemoveHandler(ClickEvent, value); }
+        }
+
+        // This method raises the PageNavigation event
+        private void RaiseClick()
+        {
+            RaiseEvent(new RoutedEventArgs(ClickEvent, this));
+        }
+
         #endregion
 
         /// <summary>


### PR DESCRIPTION
Implemented a Click event that has similar behavior to that of Button controls, which do not fire the Click event until the button is released. Here, the Click event is only wanted if the user doesn't drag the control.

Several changes are made to DragBehavior, mainly to reduce conflicts between VertexControl and DragBehavior trying to handle the same events and conflicting with each other. For example, prior to these changes, the VertexControl was not getting the MouseUp events it was expecting.

VertexControl MouseDoubleClick handler no longer marks the event handled because it prevents parent controls from receiving the bubbling event. Marking the other mouse events handled might be undesirable as well because notifying the RootArea of the events doesn't necessarily mean other elements of the visual tree shouldn't get a chance at the event. The corresponding RootArea events are fine, but they are different events and bypass the rest of the bubbling that the events on the VertexControl would continue through. In my opinion, the event handlers of the VertexControl should not mark the events handled, but I have only changed that for MouseDoubleClick at this time.

PLEASE NOTE: My development system is Windows 7 and I'm not in a position to test the METRO changes at this time. I modified the code to try to get it close, but it needs to be checked. I apologize that I can't do that right now.
