### PR TITLE
Call ApplyTemplate during deserialization

### DIFF
--- a/GraphX.Controls/Controls/GraphArea.cs
+++ b/GraphX.Controls/Controls/GraphArea.cs
@@ -1615,7 +1615,8 @@ namespace GraphX.Controls
                 ctrl.SetPosition(item.Position.X, item.Position.Y);
                 AddVertex(vertexdata, ctrl);
                 LogicCore.Graph.AddVertex(vertexdata);
-            }
+				ctrl.ApplyTemplate();
+			}
             var elist = data.Where(a => a.Data is TEdge);
 
             foreach (var item in elist)


### PR DESCRIPTION
Deserialization can fail if vertex connection points are not created prior to deserializing an edge that uses a connection point. Calling ApplyTemplate on each vertex ensures the visual tree is created and VertexControlBase.VertexConnectionPointsList is populated.
