### PR TITLE
Modifications to prevent negative numbers passed to Size and Rect

### DIFF
--- a/GraphX.Controls/Controls/GraphArea.cs
+++ b/GraphX.Controls/Controls/GraphArea.cs
@@ -616,7 +616,7 @@ namespace GraphX.Controls
             }
             catch (Exception ex)
             {
-                throw new GX_GeneralException(ex.Message + ". Probably you have an error in edge template.");
+                throw new GX_GeneralException(ex.Message + ". Probably you have an error in edge template.", ex);
             }
         }
 

--- a/GraphX.Controls/Controls/ZoomControl/ViewFinderDisplay.cs
+++ b/GraphX.Controls/Controls/ZoomControl/ViewFinderDisplay.cs
@@ -181,7 +181,7 @@ namespace GraphX.Controls
                 double aspectX = availableSize.Width/displayPanelSize.Width;
                 double aspectY = availableSize.Height/displayPanelSize.Height;
                 double scale = (aspectX < aspectY) ? aspectX : aspectY;
-                displayPanelSize = new Size(displayPanelSize.Width*scale, displayPanelSize.Height*scale);
+                displayPanelSize = new Size(Math.Max(0, displayPanelSize.Width * scale), Math.Max(0, displayPanelSize.Height * scale));
             }
 
             return displayPanelSize;

--- a/GraphX.Controls/Controls/ZoomControl/ZoomControl.cs
+++ b/GraphX.Controls/Controls/ZoomControl/ZoomControl.cs
@@ -594,7 +594,7 @@ namespace GraphX.Controls
                 // adjust the viewport from the coordinate space of the Content element
                 // to the coordinate space of the view finder display panel
                 var scale = _viewFinderDisplay.Scale;// *_viewboxFactor;
-                _viewFinderDisplay.ViewportRect = new Rect(viewport.Left * scale, viewport.Top * scale, viewport.Width * scale, viewport.Height * scale);
+                _viewFinderDisplay.ViewportRect = new Rect(viewport.Left * scale, viewport.Top * scale, Math.Max(0.0, viewport.Width * scale), Math.Max(0.0, viewport.Height * scale));
             }
         }
 
@@ -621,12 +621,12 @@ namespace GraphX.Controls
             if (viewFinderSize.Width > 0d && DoubleHelper.AreVirtuallyEqual(viewFinderSize.Height, 0d))
             {
                 // update height to accomodate width, while keeping a ratio equal to the actual content
-                viewFinderSize = new Size(viewFinderSize.Width, contentSize.Height * viewFinderSize.Width / contentSize.Width);
+                viewFinderSize = new Size(viewFinderSize.Width, Math.Max(0, contentSize.Height * viewFinderSize.Width / contentSize.Width));
             }
             else if (viewFinderSize.Height > 0d && DoubleHelper.AreVirtuallyEqual(viewFinderSize.Width, 0d))
             {
                 // update width to accomodate height, while keeping a ratio equal to the actual content
-                viewFinderSize = new Size(contentSize.Width * viewFinderSize.Height / contentSize.Height, viewFinderSize.Width);
+                viewFinderSize = new Size(Math.Max(0, contentSize.Width * viewFinderSize.Height / contentSize.Height), viewFinderSize.Width);
             }
 
             // determine the scale of the view finder display panel
@@ -642,7 +642,7 @@ namespace GraphX.Controls
 
             // set the ContentBounds and Scale properties on the view finder display panel
             _viewFinderDisplay.Scale = scale;
-            _viewFinderDisplay.ContentBounds = new Rect(new Size(vbWidth, vbHeight));
+            _viewFinderDisplay.ContentBounds = new Rect(new Size(Math.Max(0, vbWidth), Math.Max(0, vbHeight)));
         }
 
         private void UpdateViewboxFactor()

--- a/GraphX.PCL.Common/Exceptions/GX_GeneralException.cs
+++ b/GraphX.PCL.Common/Exceptions/GX_GeneralException.cs
@@ -8,5 +8,10 @@ namespace GraphX.PCL.Common.Exceptions
             : base(text)
         {
         }
-    }
+
+		public GX_GeneralException(string text, Exception innerException)
+			: base(text, innerException)
+		{
+		}
+	}
 }


### PR DESCRIPTION
I have intermittent problems with negative numbers being passed to Size and Rect constructors. The stack traces allow me to narrow the problem down to certain methods, but not the exact lines. This pull request includes modifications to prevent negative numbers passed to Size and Rect constructors. It also includes some modifications to prevent information loss when throwing GX_GeneralException.

Please note: My changes were originally made on a version from mid December, before some of your optimizations and other changes in ZoomControl. I don't know whether your other changes also prevent the exceptions I've seen because I haven't had much time using that newer code yet. I've merged my changes with your newest code and that is what's in the pull request.
