### PR TITLE
Drag selection and edge dragging

### DIFF
--- a/GraphX.Controls/Controls/EdgeControl.cs
+++ b/GraphX.Controls/Controls/EdgeControl.cs
@@ -384,7 +384,7 @@ namespace GraphX.Controls
         {
             if (RootArea != null && Visibility == Visibility.Visible)
                 RootArea.OnEdgeMouseMove(this, null, Keyboard.Modifiers);
-            e.Handled = true;
+            // e.Handled = true;
         }
 
         void EdgeControl_MouseDoubleClick(object sender, MouseButtonEventArgs e)

--- a/GraphX.Controls/Controls/GraphAreaBase.cs
+++ b/GraphX.Controls/Controls/GraphAreaBase.cs
@@ -321,6 +321,21 @@ namespace GraphX
         }
 
         /// <summary>
+        /// Fires when vertex is clicked
+        /// </summary>
+        public event VertexClickedEventHandler VertexClicked;
+
+        internal virtual void OnVertexClicked(VertexControl vc, MouseButtonEventArgs e, ModifierKeys keys)
+        {
+            VertexClicked?.Invoke(this, new VertexClickedEventArgs(vc, e
+#if WPF
+                , keys));
+#elif METRO
+                    ));
+#endif
+        }
+
+        /// <summary>
         /// Fires when mouse up on vertex
         /// </summary>
         public event VertexSelectedEventHandler VertexMouseUp;

--- a/GraphX.Controls/Controls/VertexControl.cs
+++ b/GraphX.Controls/Controls/VertexControl.cs
@@ -171,7 +171,8 @@ namespace GraphX.Controls
                 RootArea.OnVertexMouseUp(this, e, Keyboard.Modifiers);
                 if (_clickTrack)
                 {
-                    RaiseClick();
+                    RaiseEvent(new RoutedEventArgs(ClickEvent, this));
+                    RootArea.OnVertexClicked(this, e, Keyboard.Modifiers);
                 }
             }
             _clickTrack = false;
@@ -202,12 +203,6 @@ namespace GraphX.Controls
         {
             add { AddHandler(ClickEvent, value); }
             remove { RemoveHandler(ClickEvent, value); }
-        }
-
-        // This method raises the PageNavigation event
-        private void RaiseClick()
-        {
-            RaiseEvent(new RoutedEventArgs(ClickEvent, this));
         }
 
         #endregion

--- a/GraphX.Controls/Controls/ZoomControl/ZoomControl.cs
+++ b/GraphX.Controls/Controls/ZoomControl/ZoomControl.cs
@@ -681,6 +681,9 @@ namespace GraphX.Controls
             DependencyProperty.Register(nameof(AnimationLength), typeof(TimeSpan), typeof(ZoomControl),
                                         new PropertyMetadata(TimeSpan.FromMilliseconds(500)));
 
+        public static readonly DependencyProperty IsDragSelectByDefaultProperty =
+            DependencyProperty.Register(nameof(IsDragSelectByDefaultProperty), typeof(bool), typeof(ZoomControl), new PropertyMetadata(false));
+
         public static readonly DependencyProperty MaximumZoomStepProperty =
             DependencyProperty.Register("MaximumZoomValueValue", typeof(double), typeof(ZoomControl),
                                         new PropertyMetadata(5.0));
@@ -927,6 +930,15 @@ namespace GraphX.Controls
         {
             get { return (TimeSpan)GetValue(AnimationLengthProperty); }
             set { SetValue(AnimationLengthProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the value indicating whether to drag select without keyboard modifiers to the mouse button.
+        /// </summary>
+        public bool IsDragSelectByDefault
+        {
+            get { return (bool)GetValue(IsDragSelectByDefaultProperty); }
+            set { SetValue(IsDragSelectByDefaultProperty, value); }
         }
 
         /// <summary>
@@ -1267,7 +1279,17 @@ namespace GraphX.Controls
             {
                 case ModifierKeys.None:
                     if (!isPreview)
-                        ModifierMode = ZoomViewModifierMode.Pan;
+                    {
+                        if (IsDragSelectByDefault)
+                        {
+                            _startedAsAreaSelection = true;
+                            ModifierMode = ZoomViewModifierMode.ZoomBox;
+                        }
+                        else
+                        {
+                            ModifierMode = ZoomViewModifierMode.Pan;
+                        }
+                    }
                     break;
                 case ModifierKeys.Alt | ModifierKeys.Control:
                     _startedAsAreaSelection = true;

--- a/GraphX.Controls/GraphX.WPF.Controls.csproj
+++ b/GraphX.Controls/GraphX.WPF.Controls.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Models\PropertyChangeNotifier.cs" />
     <Compile Include="Models\RemoveControlEventHandler.cs" />
     <Compile Include="Models\StateStorage.cs" />
+    <Compile Include="Models\VertexClickedEventArgs.cs" />
     <Compile Include="Models\VertexEventOptions.cs" />
     <Compile Include="Models\DefaultLabelFactory.cs" />
     <Compile Include="Models\VertexMovedEventArgs.cs" />

--- a/GraphX.Controls/Models/VertexClickedEventArgs.cs
+++ b/GraphX.Controls/Models/VertexClickedEventArgs.cs
@@ -1,0 +1,19 @@
+﻿
+using System.Windows.Input;
+
+namespace GraphX.Controls.Models
+{
+    public sealed class VertexClickedEventArgs : System.EventArgs
+    {
+        public VertexControl VertexControl { get; private set; }
+        public MouseButtonEventArgs MouseArgs { get; private set; }
+        public ModifierKeys Modifiers { get; private set; }
+
+        public VertexClickedEventArgs(VertexControl vc, MouseEventArgs e, ModifierKeys keys)
+        {
+            VertexControl = vc;
+            MouseArgs = e as MouseButtonEventArgs;
+            Modifiers = keys;
+        }
+    }
+}

--- a/GraphX.Controls/Models/VertexSelectedEventHandler.cs
+++ b/GraphX.Controls/Models/VertexSelectedEventHandler.cs
@@ -2,6 +2,7 @@ namespace GraphX.Controls.Models
 {
     public delegate void VertexSelectedEventHandler(object sender, VertexSelectedEventArgs args);
     public delegate void VertexMovedEventHandler(object sender, VertexMovedEventArgs e);
+    public delegate void VertexClickedEventHandler(object sender, VertexClickedEventArgs args);
 
 
     public delegate void ContentSizeChangedEventHandler(object sender, ContentSizeChangedEventArgs e);

--- a/GraphX.METRO.Controls/GraphX.METRO.Controls.csproj
+++ b/GraphX.METRO.Controls/GraphX.METRO.Controls.csproj
@@ -319,6 +319,7 @@
     <Compile Include="Models\FileServiceProviderMETRO.cs" />
     <Compile Include="Models\ModifierKeys.cs" />
     <Compile Include="Models\MouseButtonEventArgs.cs" />
+    <Compile Include="Models\VertexClickedEventArgs.cs" />
     <Compile Include="Models\VertexMovedEventArgs.cs" />
     <Compile Include="Models\VertexSelectedEventArgs.cs" />
     <Compile Include="Models\XamlTypes\ViewModelBase.cs" />

--- a/GraphX.METRO.Controls/Models/VertexClickedEventArgs.cs
+++ b/GraphX.METRO.Controls/Models/VertexClickedEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using Windows.UI.Xaml.Input;
+
+namespace GraphX.Controls.Models
+{
+    public sealed class VertexClickedEventArgs : System.EventArgs
+    {
+        public VertexControl VertexControl { get; private set; }
+        public PointerRoutedEventArgs Args { get; private set; }
+
+        public VertexClickedEventArgs(VertexControl vc, PointerRoutedEventArgs e)
+        {
+            VertexControl = vc;
+            Args = e;
+        }
+    }
+}


### PR DESCRIPTION
In my application, we want to have drag selection instead of panning as the unmodified mouse drag behavior for ZoomControl. I added a flag that can be used to achieve this. By default, it will use the original panning behavior. When IsDragSelectByDefault is set to true, dragging without modifier keys will do a drag selection, but holding shift will still pan.

I also wanted the ability to drag an edge and have its connected vertices move with it. To achieve this, I modified some of the EdgeControl and DragBehavior code. An application developer can then tag the connected vertices when an edge is selected and than dragging the edge will update the VertexControl positions. It was necessary to update the OriginalX and OriginalY with each move in order to get the edge based dragging to work correctly.
