### PR TITLE
Fixed an issue with SimpleEdgeRouting start and end points.

### DIFF
--- a/GraphX.PCL.Logic/Algorithms/EdgeRouting/SimpleER/SimpleEdgeRouting.cs
+++ b/GraphX.PCL.Logic/Algorithms/EdgeRouting/SimpleER/SimpleEdgeRouting.cs
@@ -62,12 +62,14 @@ namespace GraphX.PCL.Logic.Algorithms.EdgeRouting
             //bad edge data check
             if (ctrl.Source.ID == -1 || ctrl.Target.ID == -1)
                 throw new GX_InvalidDataException("SimpleEdgeRouting() -> You must assign unique ID for each vertex to use SimpleER algo!");
-            if (ctrl.Source.ID == ctrl.Target.ID || !VertexPositions.ContainsKey(ctrl.Target)) return;
+            if (ctrl.Source.ID == ctrl.Target.ID || !VertexSizes.ContainsKey(ctrl.Source) || !VertexSizes.ContainsKey(ctrl.Target)) return;
 
-            var startPoint = VertexPositions[ctrl.Source];// new Point(GraphAreaBase.GetX(ctrl.Source), GraphAreaBase.GetY(ctrl.Source));
-            var endPoint = VertexPositions[ctrl.Target];// new Point(GraphAreaBase.GetX(ctrl.Target), GraphAreaBase.GetY(ctrl.Target));
+			var ss = VertexSizes[ctrl.Source];
+			var es = VertexSizes[ctrl.Target];
+            var startPoint = new Point(ss.X + ss.Width * 0.5, ss.Y + ss.Height * 0.5);
+            var endPoint = new Point(es.X + es.Width * 0.5, es.Y + es.Height * 0.5);
 
-            if (startPoint == endPoint) return;
+			if (startPoint == endPoint) return;
 
             var originalSizes = getSizesCollection(ctrl, endPoint);
             var checklist = new Dictionary<TVertex, KeyValuePair<TVertex, Rect>>(originalSizes);


### PR DESCRIPTION
The SimpleEdgeRouting code was using vertex upper left corners as the start and end points, but edges are rendered from/to the center of the vertex. This could result in some bad routing because the collision checks can give different results using the upper left corners vs. using the centers.
