### PR TITLE
RemoveEdge() was not passing the optional removeEdgeFromDataGraph

### DIFF
--- a/GraphX.Controls/Controls/GraphArea.cs
+++ b/GraphX.Controls/Controls/GraphArea.cs
@@ -414,7 +414,7 @@ namespace GraphX.Controls
         /// <param name="removeEdgeFromDataGraph">Remove edge from data graph if possible. Default value is False.</param>
         public void RemoveEdge(TEdge edgeData, bool removeEdgeFromDataGraph = false)
         {
-            RemoveEdgeInternal(edgeData, true);
+            RemoveEdgeInternal(edgeData, true, removeEdgeFromDataGraph);
             var hasStorage = LogicCore?.AlgorithmStorage != null && (edgeData.SkipProcessing != ProcessingOptionEnum.Exclude || removeEdgeFromDataGraph);
             if (hasStorage) LogicCore.AlgorithmStorage.RemoveSingleEdge(edgeData);
         }


### PR DESCRIPTION
RemoveEdge() was not passing the optional removeEdgeFromDataGraph parameter in its call to RemoveEdgeInternal(). As a result, edges were sometimes being regenerated during graph layout, particularly when the last edge was removed from _edgeList and _finishUpRelayoutGraph() was called.