### PR TITLE
Bugfix: Must take polymorphic controls into consideration.

### DIFF
--- a/GraphX.Controls/Behaviours/DragBehaviour.cs
+++ b/GraphX.Controls/Behaviours/DragBehaviour.cs
@@ -353,12 +353,12 @@ namespace GraphX.Controls
             {
                 //register the event handlers
 #if WPF
-                if (element.GetType() == typeof(VertexControl))
+                if (element is VertexControl)
                 {
                     element.MouseLeftButtonDown += OnVertexDragStarted;
                     element.PreviewMouseLeftButtonUp += OnVertexDragFinished;
                 }
-                else if (element.GetType() == typeof(EdgeControl))
+                else if (element is EdgeControl)
                 {
                     element.MouseLeftButtonDown += OnEdgeDrageStarted;
                     element.PreviewMouseLeftButtonUp += OnEdgeDragFinished;
@@ -372,12 +372,12 @@ namespace GraphX.Controls
             {
                 //unregister the event handlers
 #if WPF
-                if (element.GetType() == typeof(VertexControl))
+                if (element is VertexControl)
                 {
                     element.MouseLeftButtonDown -= OnVertexDragStarted;
                     element.PreviewMouseLeftButtonUp -= OnVertexDragFinished;
                 }
-                else if (element.GetType() == typeof(EdgeControl))
+                else if (element is EdgeControl)
                 {
                     element.MouseLeftButtonDown -= OnEdgeDrageStarted;
                     element.PreviewMouseLeftButtonUp -= OnEdgeDragFinished;

--- a/GraphX.Controls/Behaviours/DragBehaviour.cs
+++ b/GraphX.Controls/Behaviours/DragBehaviour.cs
@@ -491,16 +491,13 @@ namespace GraphX.Controls
             SetOriginalX(obj, GraphAreaBase.GetFinalX(obj));
             SetOriginalY(obj, GraphAreaBase.GetFinalY(obj));
 
-            // Save starting position of all tagged elements
-            if (GetIsTagged(obj))
-            {
-                foreach (var item in area.GetAllVertexControls())
-                    if (GetIsTagged(item))
-                    {
-                        SetOriginalX(item, GraphAreaBase.GetFinalX(item));
-                        SetOriginalY(item, GraphAreaBase.GetFinalY(item));
-                    }
-            }
+            // Save starting position of all other tagged elements
+            foreach (var item in area.GetAllVertexControls())
+                if (!ReferenceEquals(item, obj) && GetIsTagged(item))
+                {
+                    SetOriginalX(item, GraphAreaBase.GetFinalX(item));
+                    SetOriginalY(item, GraphAreaBase.GetFinalY(item));
+                }
 
             //capture the mouse
 #if WPF


### PR DESCRIPTION
This made our code go bonkers, as we have several subtypes of Vertex and EdgeControl. We need subtyping, because we template them differently.