### PR TITLE
Fixes binding errors and strange 2x2 pixel displayed on click

### DIFF
--- a/GraphX.Controls/Controls/ZoomControl/ZoomControl.cs
+++ b/GraphX.Controls/Controls/ZoomControl/ZoomControl.cs
@@ -1240,7 +1240,7 @@ namespace GraphX.Controls
                         _startedAsAreaSelection = false;
 
                         OnAreaSelected(ToContentRectangle(ZoomBox));
-                        ZoomBox = Rect.Empty;
+                        ZoomBox = new Rect();
                     }
                     else ZoomToInternal(ZoomBox);
                     break;


### PR DESCRIPTION
When the property IsDragSelectByDefault is set to true and the user clicks on the zoom area, the ZoomBox is being set to empty and this breaks bindings resulting in the Canvas/Border 2x2 element to actually be rendered as an annoying random pixel in the upper left corder of the Zoom control.