### PR TITLE
Update GraphArea.cs

### DIFF
--- a/GraphX.Controls/Controls/GraphArea.cs
+++ b/GraphX.Controls/Controls/GraphArea.cs
@@ -1740,11 +1740,11 @@ namespace GraphX.Controls
             if (ec == null) return list;
             
             var edge = (TEdge)ec.Edge;
-            if (_vertexlist.ContainsKey(edge.Target) && edge.Target != null)
+            if (edge.Target != null && _vertexlist.ContainsKey(edge.Target))
             {
                 list.Add(_vertexlist[edge.Target]);
             }
-            if (_vertexlist.ContainsKey(edge.Source) && edge.Source != null)
+            if (edge.Source != null && _vertexlist.ContainsKey(edge.Source))
             {
                 list.Add(_vertexlist[edge.Source]);
             }

--- a/GraphX.Controls/Controls/GraphArea.cs
+++ b/GraphX.Controls/Controls/GraphArea.cs
@@ -1738,9 +1738,17 @@ namespace GraphX.Controls
             }
             var ec = ctrl as EdgeControl;
             if (ec == null) return list;
+            
             var edge = (TEdge)ec.Edge;
-            if (_vertexlist.ContainsKey(edge.Target)) list.Add(_vertexlist[edge.Target]);
-            if (_vertexlist.ContainsKey(edge.Source)) list.Add(_vertexlist[edge.Source]);
+            if (_vertexlist.ContainsKey(edge.Target) && edge.Target != null)
+            {
+                list.Add(_vertexlist[edge.Target]);
+            }
+            if (_vertexlist.ContainsKey(edge.Source) && edge.Source != null)
+            {
+                list.Add(_vertexlist[edge.Source]);
+            }
+            
             return list;
         }
 


### PR DESCRIPTION
Have noticed that sometimes during DeSerialization a failure for Source or Target to be updated properly will result in an uncaught exception to the Application Dispatcher.  It is best to test for a valid Source and Target Property value before attempting to retrieve a mapped value.