### PR TITLE
Update EdgeControlBase.cs

### DIFF
--- a/GraphX.Controls/Controls/EdgeControlBase.cs
+++ b/GraphX.Controls/Controls/EdgeControlBase.cs
@@ -566,9 +566,13 @@ namespace GraphX.Controls
                 ApplyTemplate();
             if (ShowArrows)
             {
-                EdgePointerForSource?.Show();
-                EdgePointerForTarget?.Show();
-            }
+                // Note: Do not override a possible WPF Binding or Converter for the Visibility property.
+                if (EdgePointerForSource?.Visibility == Visibility.Visible)
+                    EdgePointerForSource?.Show();
+
+                // Note: Do not override a possible WPF Binding or Converter for the Visibility property.
+                if (EdgePointerForTarget?.Visibility == Visibility.Visible)
+                    EdgePointerForTarget?.Show();            }
             else
             {
                 EdgePointerForSource?.Hide();


### PR DESCRIPTION
The latest changes that were authored resulted in a defect.  If an edge pointer Visibility happens to be set by either a Binding or Converter, then the original code was overwriting the Visibility property value.