### PR TITLE
Rewrote EdgeControl.Source & Target tracking; previously SizeChanged …

### DIFF
--- a/GraphX.Controls/Controls/EdgeControlBase.cs
+++ b/GraphX.Controls/Controls/EdgeControlBase.cs
@@ -259,10 +259,6 @@ namespace GraphX.Controls
         /// </summary>
         public bool UpdateLabelPosition { get { return _updateLabelPosition; } set { _updateLabelPosition = true; } }
 
-#if WPF
-        protected PropertyChangeNotifier _sourceWatcher;
-        protected PropertyChangeNotifier _targetWatcher;
-#endif
 
         /// <summary>
         /// Gets or set if hidden edges should be updated when connected vertices positions are changed. Default value is True.


### PR DESCRIPTION
…and PositionChanged callbacks were still bound after Clean() (indirectly due to PropertyChangeNotifier.Dispose() ClearBinding)

Old commit on our fork and would like to have it upstream so that we can use GraphX from NuGet